### PR TITLE
feat: process tags to digests in go routines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-REPOSITORY ?= sozercan/tagtodigest-provider
+REPOSITORY ?= tagtodigest-provider
 IMG := $(REPOSITORY):latest
 ARCH ?= "linux/amd64"
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-REPOSITORY ?= tagtodigest-provider
+REPOSITORY ?= sozercan/tagtodigest-provider
 IMG := $(REPOSITORY):latest
 ARCH ?= "linux/amd64"
 

--- a/README.md
+++ b/README.md
@@ -8,25 +8,43 @@ tagToDigest-provider is used for mutating image tag to a digest using [crane](ht
 
 - Deploy Gatekeeper with external data enabled (`--enable-external-data`)
 
-- `kubectl apply -f manifest`
+- `kubectl apply -f manifest/`
 
 - `kubectl apply -f policy/provider.yaml`
-  - Update `proxyURL` if it's not `http://tagtodigest-provider.default:8090`
+  - Update `url` if it's not `http://tagtodigest-provider.external-data-providers:8090/mutate`
 
 - `kubectl apply -f policy/assign.yaml`
 
 # Verification
 
-- `kubectl apply -f examples/test.yaml`
+- `kubectl apply -f policy/examples/test.yaml --dry-run=server -ojson | jq -r '.spec.template.spec.containers[].image`
 
-- `kubectl get deploy test-deployment -o yaml`
-  - you should see digests in image
+  - before:
+
   ```
-  ...
-      spec:
-      containers:
-      - image: gcr.io/distroless/static:nonroot@sha256:c9f9b040044cc23e1088772814532d90adadfa1b86dcba17d07cb567db18dc4e
-      ...
-      - image: gcr.io/distroless/static:nonroot@sha256:c9f9b040044cc23e1088772814532d90adadfa1b86dcba17d07cb567db18dc4e"
-  ...
+  gcr.io/distroless/static:nonroot
+  gcr.io/distroless/static:nonroot@sha256:c9f9b040044cc23e1088772814532d90adadfa1b86dcba17d07cb567db18dc4e
+  busybox
+  nginx:1.21.6
+  quay.io/prometheus/node-exporter:v1.3.1
+  mcr.microsoft.com/oss/kubernetes/pause:3.6
+  upstream.azurecr.io/oss/kubernetes/pause:3.6
+  public.ecr.aws/datadog/agent:latest
+  public.ecr.aws/amazonlinux/amazonlinux:latest
+  mcr.microsoft.com/oss/bitnami/redis:6.0.8
+  ```
+
+  - after:
+
+  ```
+  gcr.io/distroless/static:nonroot@sha256:80c956fb0836a17a565c43a4026c9c80b2013c83bea09f74fa4da195a59b7a99
+  gcr.io/distroless/static:nonroot@sha256:c9f9b040044cc23e1088772814532d90adadfa1b86dcba17d07cb567db18dc4e
+  busybox@sha256:caa382c432891547782ce7140fb3b7304613d3b0438834dce1cad68896ab110a
+  nginx:1.21.6@sha256:85f3b7a34506d74088124917360343e00c73a1b617a2371cc59fa9fa44d89a42
+  quay.io/prometheus/node-exporter:v1.3.1@sha256:f2269e73124dd0f60a7d19a2ce1264d33d08a985aed0ee6b0b89d0be470592cd
+  mcr.microsoft.com/oss/kubernetes/pause:3.6@sha256:b4b669f27933146227c9180398f99d8b3100637e4a0a1ccf804f8b12f4b9b8df
+  upstream.azurecr.io/oss/kubernetes/pause:3.6@sha256:1fe8b51fb6120c0504015e795b9b048f1e7a26b548ed1a7713ec20c6c69be508
+  public.ecr.aws/datadog/agent:latest@sha256:2ef4ef739b3809872bc8bb959b19c0fc665d239cae306c7adec95e63deb4ab3c
+  public.ecr.aws/amazonlinux/amazonlinux:latest@sha256:334ec0ec042eff13d9581120f80a46fb0861d6a4ba0e9f44e09650979ec5d2df
+  mcr.microsoft.com/oss/bitnami/redis:6.0.8@sha256:9b53ae0f1cf3f7d7854584c8b7c5a96fe732c48d504331da6c00f892fdcce102
   ```

--- a/manifest/deployment.yaml
+++ b/manifest/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         run: tagtodigest-provider
     spec:
       containers:
-      - image: tagtodigest-provider:latest
+      - image: sozercan/tagtodigest-provider:v0.0.1
         imagePullPolicy: IfNotPresent
         name: tagtodigest-provider
         ports:

--- a/manifest/deployment.yaml
+++ b/manifest/deployment.yaml
@@ -1,7 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: external-data-providers
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: tagtodigest-provider
+  namespace: external-data-providers
 spec:
   replicas: 1
   selector:
@@ -13,8 +19,8 @@ spec:
         run: tagtodigest-provider
     spec:
       containers:
-      - image: sozercan/tagtodigest-provider:v0.0.1
-        imagePullPolicy: Always
+      - image: tagtodigest-provider:latest
+        imagePullPolicy: IfNotPresent
         name: tagtodigest-provider
         ports:
         - containerPort: 8090

--- a/manifest/rbac.yaml
+++ b/manifest/rbac.yaml
@@ -2,6 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: provider-tagtodigest-role
+  namespace: external-data-providers
 rules:
 - apiGroups: [""]
   resources:
@@ -16,6 +17,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: provider-tagtodigest-rolebinding
+  namespace: external-data-providers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -23,10 +25,10 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: provider-tagtodigest-sa
-  namespace: default
+  namespace: external-data-providers
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: provider-tagtodigest-sa
-  namespace: default
+  namespace: external-data-providers

--- a/manifest/service.yaml
+++ b/manifest/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: tagtodigest-provider
+  namespace: external-data-providers
 spec:
   ports:
   - port: 8090

--- a/policy/assign.yaml
+++ b/policy/assign.yaml
@@ -8,6 +8,7 @@ spec:
     kinds:
     - apiGroups: ["apps"]
       kinds: ["Deployment"]
+    excludedNamespaces: ["external-data-providers"]
   applyTo:
   - groups: ["apps"]
     kinds: ["Deployment"]

--- a/policy/examples/test.yaml
+++ b/policy/examples/test.yaml
@@ -27,12 +27,12 @@ spec:
       - name: node-exporter
         image: quay.io/prometheus/node-exporter:v1.3.1
       - name: pause
-        image: mcr.microsoft.com/oss/kubernetes/pause:3.6-hotfix.20220114
+        image: mcr.microsoft.com/oss/kubernetes/pause:3.6
       - name: acr
-        image: upstream.azurecr.io/oss/kubernetes/pause:3.6-hotfix.20220114
+        image: upstream.azurecr.io/oss/kubernetes/pause:3.6
       - name: ecr
         image: public.ecr.aws/datadog/agent:latest
       - name: amazon-linux
         image: public.ecr.aws/amazonlinux/amazonlinux:latest
       - name: redis
-        image: mcr.microsoft.com/oss/bitnami/redis:6.0.8.9
+        image: mcr.microsoft.com/oss/bitnami/redis:6.0.8

--- a/policy/examples/test.yaml
+++ b/policy/examples/test.yaml
@@ -16,9 +16,23 @@ spec:
         app: test-deployment
     spec:
       containers:
-      - name: tag # should mutate to digest
+      - name: distroless # should mutate to digest
         image: gcr.io/distroless/static:nonroot
-      - name: digest # already includes digest, should not mutate
+      - name: distroless-with-sha # already includes digest, should not mutate
         image: gcr.io/distroless/static:nonroot@sha256:c9f9b040044cc23e1088772814532d90adadfa1b86dcba17d07cb567db18dc4e
-      - name: dockerhub-latest
+      - name: busybox
         image: busybox
+      - name: nginx
+        image: nginx:1.21.6
+      - name: node-exporter
+        image: quay.io/prometheus/node-exporter:v1.3.1
+      - name: pause
+        image: mcr.microsoft.com/oss/kubernetes/pause:3.6-hotfix.20220114
+      - name: acr
+        image: upstream.azurecr.io/oss/kubernetes/pause:3.6-hotfix.20220114
+      - name: ecr
+        image: public.ecr.aws/datadog/agent:latest
+      - name: amazon-linux
+        image: public.ecr.aws/amazonlinux/amazonlinux:latest
+      - name: redis
+        image: mcr.microsoft.com/oss/bitnami/redis:6.0.8.9

--- a/policy/provider.yaml
+++ b/policy/provider.yaml
@@ -3,5 +3,5 @@ kind: Provider
 metadata:
   name: tagtodigest-provider
 spec:
-  url: http://tagtodigest-provider.default:8090/mutate
+  url: http://tagtodigest-provider.external-data-providers:8090/mutate
   timeout: 1


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

- Process tags to digests in parallel using go routines instead of processing them in serial.
- Wrap `mutate` with `processTimeout` to enforce the timeout.

I tested the provider with 25 images and it took 800ms for the first request and 300ms for subsequent requests (I assume the response was cached by either crane or the HTTP server).

```
2022-03-21T22:11:38.850Z        INFO    tagToDigest-provider/main.go:147   mutate  <REDACTED>
2022-03-21T22:11:38.850Z        INFO    tagToDigest-provider/main.go:123   mutate  {"elapsed": "825.261655ms"}
2022-03-21T22:11:42.736Z        INFO    tagToDigest-provider/main.go:147        mutate  <REDACTED>
2022-03-21T22:11:42.736Z        INFO    tagToDigest-provider/main.go:123        mutate  {"elapsed": "315.762853ms"}
```